### PR TITLE
timeline paused now, created and plays after fonts and images are loaded

### DIFF
--- a/generators/createDisplayQuickUnit/templates/shared/script/Banner.js
+++ b/generators/createDisplayQuickUnit/templates/shared/script/Banner.js
@@ -21,7 +21,6 @@ export default class Banner {
       }
     }
 
-    webFontConfig.timeout = 2000;
     webFontConfig.fontactive = (e) => {
       // console.log(`${e}, was detected. The document is ready and font loading is active`)
     }
@@ -52,6 +51,9 @@ export default class Banner {
 
   setAnimation(animation){
     this.animation = animation;
+    //creates new timeline and pauses it
+    this.animation.getTimeline().paused(true);
+    // this.animation.getTimeline().eventCallback('onComplete', this.handleAnimationComplete);
   }
 
   handleExit = () => {
@@ -80,9 +82,7 @@ export default class Banner {
 
   };
 
-  async start() {
-    await this.init();
-
+  start() {
     this.animation.play();
   }
 }

--- a/generators/createDisplayQuickUnit/templates/shared/script/main.js
+++ b/generators/createDisplayQuickUnit/templates/shared/script/main.js
@@ -6,5 +6,12 @@ import Animation from "./Animation";
 import config from "richmediaconfig";
 
 const banner = new Banner(config);
-banner.setAnimation(new Animation(document.querySelector('.banner'), config));
-banner.start();
+//first load fonts, load images etc in the init animation
+banner.init().then(
+  () => {
+    //initializes animation and creates main timeline
+    banner.setAnimation(new Animation(document.querySelector('.banner'), config));
+    //plays banner
+    banner.start()
+  }
+)

--- a/generators/createDisplayUnitSet/templates/shared/script/Banner.js
+++ b/generators/createDisplayUnitSet/templates/shared/script/Banner.js
@@ -21,7 +21,6 @@ export default class Banner {
       }
     }
 
-    webFontConfig.timeout = 2000;
     webFontConfig.fontactive = (e) => {
       // console.log(`${e}, was detected. The document is ready and font loading is active`)
     }
@@ -52,6 +51,9 @@ export default class Banner {
 
   setAnimation(animation){
     this.animation = animation;
+    //creates new timeline and pauses it
+    this.animation.getTimeline().paused(true);
+    // this.animation.getTimeline().eventCallback('onComplete', this.handleAnimationComplete);
   }
 
   handleExit = () => {
@@ -80,9 +82,7 @@ export default class Banner {
 
   };
 
-  async start() {
-    await this.init();
-
+  start() {
     this.animation.play();
   }
 }

--- a/generators/createDisplayUnitSet/templates/shared/script/main.js
+++ b/generators/createDisplayUnitSet/templates/shared/script/main.js
@@ -6,5 +6,12 @@ import Animation from "./Animation";
 import config from "richmediaconfig";
 
 const banner = new Banner(config);
-banner.setAnimation(new Animation(document.querySelector('.banner'), config));
-banner.start();
+//first load fonts, load images etc in the init animation
+banner.init().then(
+  () => {
+    //initializes animation and creates main timeline
+    banner.setAnimation(new Animation(document.querySelector('.banner'), config));
+    //plays banner
+    banner.start()
+  }
+)

--- a/generators/createDisplayUnitSet/templates/shared_doubleclick/script/Banner.js
+++ b/generators/createDisplayUnitSet/templates/shared_doubleclick/script/Banner.js
@@ -32,8 +32,11 @@ export default class Banner {
     fitText([title, ctaCopy]);
   }
 
-  addAnimation(animation){
+  setAnimation(animation){
     this.animation = animation;
+    //creates new timeline and pauses it
+    this.animation.getTimeline().paused(true);
+    // this.animation.getTimeline().eventCallback('onComplete', this.handleAnimationComplete);
   }
 
   async addEventListeners() {
@@ -72,9 +75,7 @@ export default class Banner {
 
   };
 
-  async start(){
-    await this.init();
-
+  start() {
     this.animation.play();
   }
 }

--- a/generators/createDisplayUnitSet/templates/shared_doubleclick/script/main.js
+++ b/generators/createDisplayUnitSet/templates/shared_doubleclick/script/main.js
@@ -5,6 +5,13 @@ import Animation from "./Animation";
 // inherits from a other .richmediarc it will also contain those files.
 import config from "richmediaconfig";
 
-const banner = new Banner(document.querySelector('.banner'), config);
-banner.addAnimation(new Animation())
-banner.start();
+const banner = new Banner(config);
+//first load fonts, load images etc in the init animation
+banner.init().then(
+  () => {
+    //initializes animation and creates main timeline
+    banner.setAnimation(new Animation(document.querySelector('.banner'), config));
+    //plays banner
+    banner.start()
+  }
+)


### PR DESCRIPTION
closes #2
First there was the animation being loaded before initialization, now the banner initializes first, then the animation class is being loaded and then the banner starts playing with the timeline playing. Also removed timeout = 2000 for font loading since it does by default 5000 ms which is better for slower connections